### PR TITLE
Unmet Demand

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1094,6 +1094,7 @@
 	else
 		return 0
 
+
 /obj/machinery/power/apc/process()
 
 	if(stat & (BROKEN|MAINT|FORCEDISABLE))
@@ -1132,13 +1133,15 @@
 
 	if(!src.avail())
 		main_status = 0
-	else if(excess < 0)
+	else if(excess < lastused_total) //Show "low power" if leftover energy in the grid isn't enough to charge this
 		main_status = 1
+		terminal?.get_powernet()?.unmet_demand += (lastused_total-max(excess,0))
 	else
 		main_status = 2
 
 	//if(debug)
 	//	world.log << "Status: [main_status] - Excess: [excess] - Last Equip: [lastused_equip] - Last Light: [lastused_light] - Longterm: [longtermpower]"
+
 
 	if(cell && !shorted)
 
@@ -1154,9 +1157,9 @@
 
 		else		// no excess, and not enough per-apc
 
-			if((cell.charge / CELLRATE + excess) >= lastused_total)					// can we draw enough from cell+grid to cover last usage?
-				cell.charge = min(cell.maxcharge, cell.charge + CELLRATE * excess)	//recharge with what we can
-				add_load(excess)		// so draw what we can from the grid
+			if((cell.charge / CELLRATE + excess) >= lastused_total)		// can we draw enough from cell+grid to cover last usage?
+				var/use_remnant = cell.give(CELLRATE * excess)
+				add_load(use_remnant)		// so draw what we can from the grid
 				charging = 0
 
 			else	// not enough power available to run the last tick!
@@ -1210,6 +1213,7 @@
 				var/ch = min(excess * CELLRATE, cell.maxcharge * CHARGELEVEL)
 				add_load(ch/CELLRATE) // Removes the power we're taking from the grid
 				cell.give(ch) // actually recharge the cell
+
 
 			else
 				charging = 0		// stop charging

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -10,8 +10,6 @@
 	var/number = 0
 	var/netexcess = 0			// excess power on the powernet (typically avail-load)
 	var/unmet_demand = 0		// amount load would incraese if avail was arbitrarily large
-	var/debug_charging = 0
-	var/list/demanders = list()
 
 ////////////////////////////////////////////
 // POWERNET DATUM PROCS
@@ -115,15 +113,11 @@
 	viewload = 0.8 * viewload + 0.2 * load
 	viewload = round(viewload)
 
-	if(debug_charging)
-		message_admins("Last loop we had [unmet_demand] from [english_list(demanders)].")
-
 	// reset the powernet
 	load = 0
 	avail = newavail
 	newavail = 0
 	unmet_demand = 0
-	demanders = list()
 
 /datum/powernet/proc/get_electrocute_damage()
 	// cube root of power times 1,5 to 2 in increments of 10^-1

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -9,6 +9,9 @@
 	var/viewload = 0			// the load as it appears on the power console (gradually updated)
 	var/number = 0
 	var/netexcess = 0			// excess power on the powernet (typically avail-load)
+	var/unmet_demand = 0		// amount load would incraese if avail was arbitrarily large
+	var/debug_charging = 0
+	var/list/demanders = list()
 
 ////////////////////////////////////////////
 // POWERNET DATUM PROCS
@@ -112,10 +115,15 @@
 	viewload = 0.8 * viewload + 0.2 * load
 	viewload = round(viewload)
 
+	if(debug_charging)
+		message_admins("Last loop we had [unmet_demand] from [english_list(demanders)].")
+
 	// reset the powernet
 	load = 0
 	avail = newavail
 	newavail = 0
+	unmet_demand = 0
+	demanders = list()
 
 /datum/powernet/proc/get_electrocute_damage()
 	// cube root of power times 1,5 to 2 in increments of 10^-1


### PR DESCRIPTION
Tested this, makes a couple changes

* Unmet demand is now based on (lastused_total-max(excess,0)) meaning that it will acknowledge that it's going to use up the remainder of the excess essentially
* Low power notification is more broadly applied when (excess < lastused_total)

Does not do anything to the interface, that's for you to add

The main thing this makes you aware of when you see it in action is how much the demand can fluctuate as some filled cells decay enough to demand charge again, but that's a good thing.